### PR TITLE
Change Fedora 34 Beta to Fedora 34

### DIFF
--- a/gfm/sec2.md
+++ b/gfm/sec2.md
@@ -233,7 +233,7 @@ For example, to compile `sample.c`, type the following.
 
 To know how to compile Gtk4 applications, refer to the section 3 (GtkApplication and GtkApplicationWindow) and after.
 
-## Installing Fedora 34 Beta with gnome-boxes
+## Installing Fedora 34 with gnome-boxes
 
 The last part of this section is about Gnome40.
 Gnome 40 is a new version of Gnome desktop system.
@@ -245,10 +245,10 @@ See [Gnome 40 website](https://forty.gnome.org/) first.
 There are only three choices at present.
 
   - Gnome OS
-  - Fedora 34 Beta
+  - Fedora 34
   - openSUSE
 
-I've tried installing Fedora 34 Beta with gnome-boxes.
+I've tried installing Fedora 34 with gnome-boxes.
 
 There are two ways to install them.
 
@@ -263,7 +263,7 @@ Gnome-boxes creates a virtual machine in Ubuntu and Fedora will be installed to 
 
 The instruction is as follows.
 
-1. Download Fedora 34 Beta iso file.
+1. Download Fedora 34 iso file.
 There is an link at the end of [Gnome 40 website](https://forty.gnome.org/).
 2. Install gnome-boxes with apt-get command.
 ~~~


### PR DESCRIPTION
Fedora 34 (not beta) came out a while ago, so I changed all of the mentions of Fedora 34 Beta to just Fedora 34 in Section 2.