### PR TITLE
Update Supported GTK4 Distro-list

### DIFF
--- a/gfm/sec16.md
+++ b/gfm/sec16.md
@@ -683,16 +683,16 @@ It is a good practice for you to add more features.
 
 ~~~
 $ LANG=C wc tfe5/meson.build tfe5/tfeapplication.c tfe5/tfe.gresource.xml tfe5/tfe.h tfe5/tfenotebook.c tfe5/tfenotebook.h tfetextview/tfetextview.c tfetextview/tfetextview.h tfe5/tfe.ui
-   10    17   294 tfe5/meson.build
-   99   304  3205 tfe5/tfeapplication.c
-    6     9   153 tfe5/tfe.gresource.xml
-    4     6    87 tfe5/tfe.h
-  140   378  3601 tfe5/tfenotebook.c
-   15    21   241 tfe5/tfenotebook.h
-  229   671  8017 tfetextview/tfetextview.c
-   35    60   701 tfetextview/tfetextview.h
-   61   100  2073 tfe5/tfe.ui
-  599  1566 18372 total
+      10      17     294 tfe5/meson.build
+      99     304    3205 tfe5/tfeapplication.c
+       6       9     153 tfe5/tfe.gresource.xml
+       4       6      87 tfe5/tfe.h
+     140     378    3601 tfe5/tfenotebook.c
+      15      21     241 tfe5/tfenotebook.h
+     229     671    8017 tfetextview/tfetextview.c
+      35      60     701 tfetextview/tfetextview.h
+      61     100    2073 tfe5/tfe.ui
+     599    1566   18372 total
 ~~~
 
 

--- a/gfm/sec2.md
+++ b/gfm/sec2.md
@@ -245,8 +245,10 @@ See [Gnome 40 website](https://forty.gnome.org/) first.
 There are only three choices at present.
 
   - Gnome OS
-  - Fedora 34
+  - Arch Linux
+  - Fedora 34+
   - openSUSE
+  - Ubuntu 21.04+
 
 I've tried installing Fedora 34 with gnome-boxes.
 

--- a/gfm/sec9.md
+++ b/gfm/sec9.md
@@ -463,6 +463,7 @@ Application Options:
   --internal                   Don?t export functions; declare them G_GNUC_INTERNAL
   --external-data              Don?t embed resource data in the C file; assume it's linked externally instead
   --c-name                     C identifier name used for the generated source code
+  -C, --compiler               The target C compiler (default: the CC environment variable)
 
 ~~~
 

--- a/src/sec2.src.md
+++ b/src/sec2.src.md
@@ -243,8 +243,10 @@ See [Gnome 40 website](https://forty.gnome.org/) first.
 There are only three choices at present.
 
   - Gnome OS
-  - Fedora 34
+  - Arch Linux
+  - Fedora 34+
   - openSUSE
+  - Ubuntu 21.04+
 
 I've tried installing Fedora 34 with gnome-boxes.
 


### PR DESCRIPTION
This addition adds ``Ubuntu`` and ``Arch Linux`` to the supported GTK4 distros.