### PR TITLE
Meson: fix meson version requirement

### DIFF
--- a/docs/sec23.html
+++ b/docs/sec23.html
@@ -560,7 +560,7 @@ class="sourceCode numberSource xml numberLines"><code class="sourceCode xml"><sp
 <span id="cb10-10"><a href="#cb10-10"></a>&lt;/<span class="kw">schemalist</span>&gt;</span></code></pre></div>
 <p>Meson.build</p>
 <div class="sourceCode" id="cb11"><pre
-class="sourceCode numberSource numberLines"><code class="sourceCode"><span id="cb11-1"><a href="#cb11-1"></a>project(&#39;tfe&#39;, &#39;c&#39;, license : &#39;GPL-3.0-or-later&#39;, meson_version:&#39; &gt;=1.0.1&#39;, version: &#39;0.5&#39;)</span>
+class="sourceCode numberSource numberLines"><code class="sourceCode"><span id="cb11-1"><a href="#cb11-1"></a>project(&#39;tfe&#39;, &#39;c&#39;, license : &#39;GPL-3.0-or-later&#39;, meson_version:&#39;&gt;=1.0.1&#39;, version: &#39;0.5&#39;)</span>
 <span id="cb11-2"><a href="#cb11-2"></a></span>
 <span id="cb11-3"><a href="#cb11-3"></a>gtkdep = dependency(&#39;gtk4&#39;)</span>
 <span id="cb11-4"><a href="#cb11-4"></a></span>

--- a/gfm/sec23.md
+++ b/gfm/sec23.md
@@ -447,7 +447,7 @@ GSchema XML file
 Meson.build
 
 ~~~meson
- 1 project('tfe', 'c', license : 'GPL-3.0-or-later', meson_version:' >=1.0.1', version: '0.5')
+ 1 project('tfe', 'c', license : 'GPL-3.0-or-later', meson_version:'>=1.0.1', version: '0.5')
  2 
  3 gtkdep = dependency('gtk4')
  4 

--- a/src/tfe6/meson.build
+++ b/src/tfe6/meson.build
@@ -1,4 +1,4 @@
-project('tfe', 'c', license : 'GPL-3.0-or-later', meson_version:' >=1.0.1', version: '0.5')
+project('tfe', 'c', license : 'GPL-3.0-or-later', meson_version:'>=1.0.1', version: '0.5')
 
 gtkdep = dependency('gtk4')
 


### PR DESCRIPTION
The extra whitespace caused the version check to fail: `meson.build:1:64: ERROR: Meson version is 1.3.1 but project requires  >=1.0.1`
______________
Hello,
stumbled upon your repo on the search for a similar replacement to leafpad/l3afpad, but using the most recent gtk. Thank you for your work on putting the information together on how to achieve this oneself without getting lost in the daunting doc of GUI programming.
One thing I noticed when checking the source (or should I say: Checking the last page of the book, before starting at the beginning :D) should be fixed with this PR.